### PR TITLE
Skip ForwardRef tests if <3.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@master
     - name: Install

--- a/tests/test_forward_refs.py
+++ b/tests/test_forward_refs.py
@@ -10,7 +10,7 @@ from graphene_pydantic import PydanticObjectType
 import pytest
 
 if sys.version_info < (3, 7):
-    pytest.skip("ForwardRefs feature requires Python 3.7+")
+    pytest.skip("ForwardRefs feature requires Python 3.7+", allow_module_level=True)
 
 
 class FooModel(pydantic.BaseModel):

--- a/tests/test_forward_refs.py
+++ b/tests/test_forward_refs.py
@@ -1,3 +1,4 @@
+import sys
 import typing as T
 import uuid
 
@@ -5,6 +6,11 @@ import graphene
 import pydantic
 
 from graphene_pydantic import PydanticObjectType
+
+import pytest
+
+if sys.version_info < (3, 7):
+    pytest.skip("ForwardRefs feature requires Python 3.7+")
 
 
 class FooModel(pydantic.BaseModel):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # https://tox.readthedocs.io/en/latest/example/basic.html#compressing-dependency-matrix
 [tox]
-envlist = py{37,38}-graphene{20,21}-pydantic{1}
+envlist = py{36,37,38}-graphene{20,21}-pydantic{1}
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
See #34 -- it's not immediately clear when running the tests that some features require Python 3.7+. Make this clearer by skipping the tests on those platforms. Also, restore automated tests for Python 3.6 since we advertise support for it.