### PR TITLE
Upgrade to graphene v3

### DIFF
--- a/examples/departments.py
+++ b/examples/departments.py
@@ -103,37 +103,32 @@ class Query(graphene.ObjectType):
 
 
 if __name__ == "__main__":
-    from graphql.execution.executors.sync import SyncExecutor
-
     schema = graphene.Schema(query=Query)
-    result = schema.execute(
-        """
-      query {
-        listDepartments {
-          id,
-          name,
-          employees {
-            ...on Employee {
-              id
-              name
-              hiredOn
-              salary { rating }
+    query = """
+        query {
+            listDepartments {
+                id,
+                name,
+                employees {
+                    ...on Employee {
+                    id
+                    name
+                    hiredOn
+                    salary { rating }
+                }
+                ...on Manager {
+                    name
+                    salary {
+                        rating
+                        amount
+                    }
+                    teamSize
+                }
             }
-            ...on Manager {
-              name
-              salary {
-                rating
-                amount
-              }
-              teamSize
-            }
-          }
         }
-      }
-""",
-        executor=SyncExecutor(),
-        return_promise=False,
-    )
+    }
+    """
+    result = schema.execute(query)
 
     print(result.errors)
     print(json.dumps(result.data, indent=2))

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -97,7 +97,7 @@ def convert_pydantic_input_field(
     """
     declared_type = getattr(field, "type_", None)
     field_kwargs.setdefault(
-        "type",
+        "type_",
         convert_pydantic_type(
             declared_type, field, registry, parent_type=parent_type, model=model
         ),
@@ -126,7 +126,7 @@ def convert_pydantic_field(
     """
     declared_type = getattr(field, "type_", None)
     field_kwargs.setdefault(
-        "type",
+        "type_",
         convert_pydantic_type(
             declared_type, field, registry, parent_type=parent_type, model=model
         ),

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aniso8601"
-version = "7.0.0"
+version = "8.0.0"
 description = "A library for parsing ISO 8601 strings."
 category = "main"
 optional = false
@@ -123,52 +123,39 @@ python-versions = "*"
 
 [[package]]
 name = "graphene"
-version = "2.1.8"
+version = "3.0b5"
 description = "GraphQL Framework for Python"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-aniso8601 = ">=3,<=7"
-graphql-core = ">=2.1,<3"
-graphql-relay = ">=2,<3"
-six = ">=1.10.0,<2"
+aniso8601 = ">=8,<9"
+graphql-core = ">=3.1.2,<4"
+graphql-relay = ">=3.0,<4"
 
 [package.extras]
-django = ["graphene-django"]
-sqlalchemy = ["graphene-sqlalchemy"]
-test = ["pytest", "pytest-benchmark", "pytest-cov", "pytest-mock", "snapshottest", "coveralls", "promise", "six", "mock", "pytz", "iso8601"]
+dev = ["black (19.10b0)", "flake8 (>=3.7,<4)", "pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (2019.3)", "iso8601 (>=0.1,<2)"]
+test = ["pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (2019.3)", "iso8601 (>=0.1,<2)"]
 
 [[package]]
 name = "graphql-core"
-version = "2.3.2"
-description = "GraphQL implementation for Python"
+version = "3.1.2"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
 category = "main"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-promise = ">=2.3,<3"
-rx = ">=1.6,<2"
-six = ">=1.10.0"
-
-[package.extras]
-gevent = ["gevent (>=1.1)"]
-test = ["six (1.14.0)", "pyannotate (1.2.0)", "pytest (4.6.10)", "pytest-django (3.9.0)", "pytest-cov (2.8.1)", "coveralls (1.11.1)", "cython (0.29.17)", "gevent (1.5.0)", "pytest-benchmark (3.2.3)", "pytest-mock (2.0.0)"]
+python-versions = ">=3.6,<4"
 
 [[package]]
 name = "graphql-relay"
-version = "2.0.1"
-description = "Relay implementation for Python"
+version = "3.0.0"
+description = "Relay library for graphql-core-next"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6,<4"
 
 [package.dependencies]
-graphql-core = ">=2.2,<3"
-promise = ">=2.2,<3"
-six = ">=1.12"
+graphql-core = ">=3.0.0a0"
 
 [[package]]
 name = "identify"
@@ -305,20 +292,6 @@ toml = "*"
 virtualenv = ">=15.2"
 
 [[package]]
-name = "promise"
-version = "2.3"
-description = "Promises/A+ implementation for Python"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
-
-[package.extras]
-test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchmark", "mock"]
-
-[[package]]
 name = "py"
 version = "1.9.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -405,18 +378,10 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "rx"
-version = "1.6.1"
-description = "Reactive Extensions (Rx) for Python"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -513,12 +478,12 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "839356ffda10f4128a616ea60b1d0a186fd2f901170da12fb6fab580e9fa0598"
+content-hash = "1029ae021f6d5e37bd99773618818840ea4e556d124cc780bfd25eda6e90d205"
 
 [metadata.files]
 aniso8601 = [
-    {file = "aniso8601-7.0.0-py2.py3-none-any.whl", hash = "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"},
-    {file = "aniso8601-7.0.0.tar.gz", hash = "sha256:513d2b6637b7853806ae79ffaca6f3e8754bdd547048f5ccc1420aec4b714f1e"},
+    {file = "aniso8601-8.0.0-py2.py3-none-any.whl", hash = "sha256:c033f63d028b9a58e3ab0c2c7d0532ab4bfa7452bfc788fbfe3ddabd327b181a"},
+    {file = "aniso8601-8.0.0.tar.gz", hash = "sha256:529dcb1f5f26ee0df6c0a1ee84b7b27197c3c50fc3a6321d66c544689237d072"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -596,16 +561,16 @@ filelock = [
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 graphene = [
-    {file = "graphene-2.1.8-py2.py3-none-any.whl", hash = "sha256:09165f03e1591b76bf57b133482db9be6dac72c74b0a628d3c93182af9c5a896"},
-    {file = "graphene-2.1.8.tar.gz", hash = "sha256:2cbe6d4ef15cfc7b7805e0760a0e5b80747161ce1b0f990dfdc0d2cf497c12f9"},
+    {file = "graphene-3.0b5-py2.py3-none-any.whl", hash = "sha256:540224809fabfe23902c046725732c1e5367fed4472cd737aa55e02907421e82"},
+    {file = "graphene-3.0b5.tar.gz", hash = "sha256:aa2fdc9e9f468467d387da34ab895c9f8f4b821908c8e109c2bc7c2bd6eb322e"},
 ]
 graphql-core = [
-    {file = "graphql-core-2.3.2.tar.gz", hash = "sha256:aac46a9ac524c9855910c14c48fc5d60474def7f99fd10245e76608eba7af746"},
-    {file = "graphql_core-2.3.2-py2.py3-none-any.whl", hash = "sha256:44c9bac4514e5e30c5a595fac8e3c76c1975cae14db215e8174c7fe995825bad"},
+    {file = "graphql-core-3.1.2.tar.gz", hash = "sha256:c056424cbdaa0ff67446e4379772f43746bad50a44ec23d643b9bdcd052f5b3a"},
+    {file = "graphql_core-3.1.2-py3-none-any.whl", hash = "sha256:b1826fbd1c6c290f7180d758ecf9c3859a46574cff324bf35a10167533c0e463"},
 ]
 graphql-relay = [
-    {file = "graphql-relay-2.0.1.tar.gz", hash = "sha256:870b6b5304123a38a0b215a79eace021acce5a466bf40cd39fa18cb8528afabb"},
-    {file = "graphql_relay-2.0.1-py3-none-any.whl", hash = "sha256:ac514cb86db9a43014d7e73511d521137ac12cf0101b2eaa5f0a3da2e10d913d"},
+    {file = "graphql-relay-3.0.0.tar.gz", hash = "sha256:ad3f69a8b360c310c0c5611894f1e3fd5c6a5427b84f0f2cf5aee7a588bb5556"},
+    {file = "graphql_relay-3.0.0-py3-none-any.whl", hash = "sha256:b05ca0547557874f3bb1f34e4a6dce20bc60359fe6e73daaa63bb90df85f7ba9"},
 ]
 identify = [
     {file = "identify-1.5.5-py2.py3-none-any.whl", hash = "sha256:da683bfb7669fa749fc7731f378229e2dbf29a1d1337cbde04106f02236eb29d"},
@@ -659,9 +624,6 @@ pluggy = [
 pre-commit = [
     {file = "pre_commit-1.17.0-py2.py3-none-any.whl", hash = "sha256:92e406d556190503630fd801958379861c94884693a032ba66629d0351fdccd4"},
     {file = "pre_commit-1.17.0.tar.gz", hash = "sha256:cccc39051bc2457b0c0f7152a411f8e05e3ba2fe1a5613e4ee0833c1c1985ce3"},
-]
-promise = [
-    {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
 ]
 py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
@@ -732,11 +694,13 @@ regex = [
     {file = "regex-2020.9.27-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637"},
     {file = "regex-2020.9.27-cp38-cp38-win32.whl", hash = "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"},
     {file = "regex-2020.9.27-cp38-cp38-win_amd64.whl", hash = "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux1_i686.whl", hash = "sha256:84cada8effefe9a9f53f9b0d2ba9b7b6f5edf8d2155f9fdbe34616e06ececf81"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:816064fc915796ea1f26966163f6845de5af78923dfcecf6551e095f00983650"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:5d892a4f1c999834eaa3c32bc9e8b976c5825116cde553928c4c8e7e48ebda67"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c9443124c67b1515e4fe0bb0aa18df640965e1030f468a2a5dc2589b26d130ad"},
+    {file = "regex-2020.9.27-cp39-cp39-win32.whl", hash = "sha256:49f23ebd5ac073765ecbcf046edc10d63dcab2f4ae2bce160982cb30df0c0302"},
+    {file = "regex-2020.9.27-cp39-cp39-win_amd64.whl", hash = "sha256:3d20024a70b97b4f9546696cbf2fd30bae5f42229fbddf8661261b1eaff0deb7"},
     {file = "regex-2020.9.27.tar.gz", hash = "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d"},
-]
-rx = [
-    {file = "Rx-1.6.1-py2.py3-none-any.whl", hash = "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"},
-    {file = "Rx-1.6.1.tar.gz", hash = "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphene_pydantic"
-version = "0.1.0"
+version = "0.2.0"
 description = "Graphene Pydantic integration"
 readme = "README.md"
 repository = "https://github.com/upsidetravel/graphene-pydantic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = ["api", "graphql", "protocol", "rest", "relay", "graphene", "pydantic
 [tool.poetry.dependencies]
 python = "^3.6"
 # To keep things simple, we only support newer versions of Graphene & Pydantic
-graphene = ">=2.1.3,<3"
+graphene = ">=3.0b5"
 pydantic = ">=1.0,<1.7"
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_forward_refs.py
+++ b/tests/test_forward_refs.py
@@ -77,34 +77,29 @@ class Query(graphene.ObjectType):
 
 
 def test_query():
-    from graphql.execution.executors.sync import SyncExecutor
-
     schema = graphene.Schema(query=Query)
-    result = schema.execute(
-        """
-      query {
-        listFoos {
-          id
-          name
-          bar {
-            id
-            name
-            foo {
-              id
-              baz {
+    query = """
+        query {
+            listFoos {
+                id
                 name
-                bar { id }
-              }
+                bar {
+                    id
+                    name
+                    foo {
+                        id
+                        baz {
+                            name
+                            bar { id }
+                        }
+                    }
+                }
+                baz { name }
+                someBars { id }
             }
-          }
-          baz { name }
-          someBars { id }
         }
-    }
-    """,
-        executor=SyncExecutor(),
-        return_promise=False,
-    )
+    """
+    result = schema.execute(query)
 
     assert result.errors is None
     assert result.data is not None

--- a/tests/test_graphene.py
+++ b/tests/test_graphene.py
@@ -59,24 +59,19 @@ class Mutation(graphene.ObjectType):
 
 
 def test_query():
-    from graphql.execution.executors.sync import SyncExecutor
-
     global foo_bars
     foo_bars = [FooBar(name="test", count=1)]
 
     schema = graphene.Schema(query=Query)
-    result = schema.execute(
-        """
+    query = """
         query {
             listFooBars {
-            name
-            count
+                name
+                count
             }
         }
-        """,
-        executor=SyncExecutor(),
-        return_promise=False,
-    )
+    """
+    result = schema.execute(query)
 
     assert result.errors is None
     assert result.data is not None
@@ -84,24 +79,19 @@ def test_query():
 
 
 def test_query_with_match():
-    from graphql.execution.executors.sync import SyncExecutor
-
     global foo_bars
     foo_bars = [FooBar(name="test", count=1)]
 
     schema = graphene.Schema(query=Query)
-    result = schema.execute(
-        """
+    query = """
         query {
             listFooBars(match: {name: "test", count: 1}) {
-            name
-            count
+                name
+                count
             }
         }
-        """,
-        executor=SyncExecutor(),
-        return_promise=False,
-    )
+    """
+    result = schema.execute(query)
 
     assert result.errors is None
     assert result.data is not None
@@ -109,26 +99,20 @@ def test_query_with_match():
 
 
 def test_mutation():
-    from graphql.execution.executors.sync import SyncExecutor
-
     global foo_bars
     foo_bars = []
 
-    schema = graphene.Schema(mutation=Mutation)
+    schema = graphene.Schema(query=Query, mutation=Mutation)
     new_foo_bar = FooBar(name="mutant", count=-1)
-    result = schema.execute(
-        """
+    query = """
         mutation {
             createFooBar(data: {name: "%s", count: %d}) {
-            name
-            count
+                name
+                count
             }
         }
-        """
-        % (new_foo_bar.name, new_foo_bar.count),
-        executor=SyncExecutor(),
-        return_promise=False,
-    )
+    """ % (new_foo_bar.name, new_foo_bar.count)
+    result = schema.execute(query)
 
     assert result.errors is None
     assert result.data is not None

--- a/tests/test_graphene.py
+++ b/tests/test_graphene.py
@@ -111,7 +111,10 @@ def test_mutation():
                 count
             }
         }
-    """ % (new_foo_bar.name, new_foo_bar.count)
+    """ % (
+        new_foo_bar.name,
+        new_foo_bar.count,
+    )
     result = schema.execute(query)
 
     assert result.errors is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 # https://tox.readthedocs.io/en/latest/example/basic.html#compressing-dependency-matrix
 [tox]
-envlist = py{36,37,38}-graphene{20,21}-pydantic{1}
+envlist = py{36,37,38}-graphene{20,21,30}-pydantic{1}
 isolated_build = true
 
 [testenv]
 whitelist_externals = poetry
 deps =
+    graphene30: graphene>=3.0b5
     graphene20: graphene>=2.0,<2.1
     graphene21: graphene>=2.1,<3.0
     pydantic1: pydantic>=1.0,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 # https://tox.readthedocs.io/en/latest/example/basic.html#compressing-dependency-matrix
 [tox]
-envlist = py{36,37,38}-graphene{20,21,30}-pydantic{1}
+envlist = py{36,37,38}-graphene{30}-pydantic{1}
 isolated_build = true
 
 [testenv]
 whitelist_externals = poetry
 deps =
     graphene30: graphene>=3.0b5
-    graphene20: graphene>=2.0,<2.1
-    graphene21: graphene>=2.1,<3.0
     pydantic1: pydantic>=1.0,<2.0
     pytest
     pytest-cov


### PR DESCRIPTION
Hey, I just spend some time upgrading to graphene v3, it was surprisingly uncomplicated. Tests are green on my end, so lets see what CI has to say ;) Unfortunately I dont have a project using graphene-pydantic, so I had no chance to test my changes in a realistic environment. This PR will solve #36.

I might messed up the `tox.ini` file in an attempt to add graphene v3 there. (lemme know).

Just for reference: [the graphene v3 update tracking issue](https://github.com/graphql-python/graphene/issues/1127). It was decided in [this comment](https://github.com/graphql-python/graphene/issues/1127#issuecomment-670318972) that all graphene integrations shall be updated to graphene v3 before graphene itself will exit beta. (thats why I updated this package, even though I dont use it).