### PR TITLE
Return registry placeholder for `BaseModel` when resolving type

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -208,6 +208,9 @@ def find_graphene_type(
         # we can put a placeholder in and request that `resolve_placeholders()`
         # be called to update it.
         registry.add_placeholder_for_model(type_)
+        return find_graphene_type(
+            type_, field, registry, parent_type=parent_type, model=model
+        )
     # NOTE: this has to come before any `issubclass()` checks, because annotated
     # generic types aren't valid arguments to `issubclass`
     elif hasattr(type_, "__origin__"):

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -208,9 +208,7 @@ def find_graphene_type(
         # we can put a placeholder in and request that `resolve_placeholders()`
         # be called to update it.
         registry.add_placeholder_for_model(type_)
-        return find_graphene_type(
-            type_, field, registry, parent_type=parent_type, model=model
-        )
+        return registry.get_type_for_model(type_)
     # NOTE: this has to come before any `issubclass()` checks, because annotated
     # generic types aren't valid arguments to `issubclass`
     elif hasattr(type_, "__origin__"):


### PR DESCRIPTION
# Return Placeholder when resolving graphene type

I believe this is a bug. 

Currently, when running `find_graphene_type` with a Pydantic `BaseModel`, it will return `None`, which breaks in graphene/graphql with 

`TypeError: MODEL fields cannot be resolved. Expected Graphene type, but received: None.`

The change proposes returning the `Placeholder` object instead of `None`.  

I chose to recall the function, but we could equally do `return registry.get_type_for_model(type_)`. 