### PR TITLE
Copy pydantic model docstring to graphene model

### DIFF
--- a/graphene_pydantic/objecttype.py
+++ b/graphene_pydantic/objecttype.py
@@ -86,7 +86,8 @@ class PydanticObjectType(graphene.ObjectType):
         if not registry:
             registry = get_global_registry(PydanticObjectType)
 
-        cls.__doc__ = model.__doc__
+        if not cls.__doc__:
+            cls.__doc__ = model.__doc__
         
         pydantic_fields = yank_fields_from_attrs(
             construct_fields(

--- a/graphene_pydantic/objecttype.py
+++ b/graphene_pydantic/objecttype.py
@@ -86,6 +86,8 @@ class PydanticObjectType(graphene.ObjectType):
         if not registry:
             registry = get_global_registry(PydanticObjectType)
 
+        cls.__doc__ = model.__doc__
+        
         pydantic_fields = yank_fields_from_attrs(
             construct_fields(
                 obj_type=cls,

--- a/graphene_pydantic/objecttype.py
+++ b/graphene_pydantic/objecttype.py
@@ -88,7 +88,7 @@ class PydanticObjectType(graphene.ObjectType):
 
         if not cls.__doc__:
             cls.__doc__ = model.__doc__
-        
+
         pydantic_fields = yank_fields_from_attrs(
             construct_fields(
                 obj_type=cls,


### PR DESCRIPTION
# Support adding Pydantic model docstring to graphene model

Copies the Pydantic model docstring to the PydanticObjectType if no docstring is set on PydanticObjectType.  This allows for the docstring to appear in schema generation.