### PR TITLE
Make it graphene 2 compatible

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -130,12 +130,12 @@ def convert_pydantic_field(
     #   from the field's base model
     # - maybe even (Sphinx-style) parse attribute documentation
     field_kwargs.setdefault("description", field.field_info.description)
+    
+    field_type = field_kwargs.pop("type")
+    if "type_" in field_kwargs:
+        field_type = field_kwargs.pop("type_")
 
-    # Somehow, this happens
-    if "type_" not in field_kwargs and "type" in field_kwargs:
-        field_kwargs["type_"] = field_kwargs.pop("type")
-
-    return Field(resolver=get_attr_resolver(field.name), **field_kwargs)
+    return Field(field_type, resolver=get_attr_resolver(field.name), **field_kwargs)
 
 
 def convert_pydantic_type(

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -130,10 +130,11 @@ def convert_pydantic_field(
     #   from the field's base model
     # - maybe even (Sphinx-style) parse attribute documentation
     field_kwargs.setdefault("description", field.field_info.description)
-    
-    field_type = field_kwargs.pop("type")
-    if "type_" in field_kwargs:
-        field_type = field_kwargs.pop("type_")
+
+    # Handle Graphene 2 and 3
+    field_type = field_kwargs.pop("type", field_kwargs.pop("type_", None))
+    if field_type is None:
+        raise ValueError("No field type could be determined.")
 
     return Field(field_type, resolver=get_attr_resolver(field.name), **field_kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["api", "graphql", "protocol", "rest", "relay", "graphene", "pydantic
 [tool.poetry.dependencies]
 python = "^3.7"
 # To keep things simple, we only support newer versions of Graphene & Pydantic
-graphene = "~=3.0"
+graphene = ">=2.1.8"
 pydantic = [
     { version = ">=1.0,<2.0", python = ">3.6,<3.10" },
     { version = ">=1.9,<2.0", python = "~3.10" }

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # https://tox.readthedocs.io/en/latest/example/basic.html#compressing-dependency-matrix
 [tox]
 # NOTE: Pydantic <1.9 does not support Python 3.10
-envlist = py{37,38,39}-graphene{30}-pydantic{17,18,19}, py310-graphene30-pydantic19
+envlist = py{37,38,39}-graphene{21,30}-pydantic{17,18,19}, py310-graphene30-pydantic19
 # CI will supply any versions not available locally
 skip_missing_interpreters = True
 # required if working with pyproject.toml
@@ -12,6 +12,7 @@ requires =
 [testenv]
 whitelist_externals = poetry
 deps =
+    graphene21: graphene>=2.1.8
     graphene30: graphene>=3.0,<3.1
     pydantic17: pydantic==1.7
     pydantic18: pydantic==1.8


### PR DESCRIPTION
# Title

From `graphene 2.*` to `graphene 3.0`, the name of the first argument for `graphene.types.field.Field.__init__` changed from `type` to `type_`, which caused some incompatibility issue.  This PR is to fix the issue to make sure that it can also work well with `graphene.2.*`.
