### PR TITLE
convert_pydantic_input_field fix: "type_" to "type"

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -89,7 +89,7 @@ def convert_pydantic_input_field(
     """
     declared_type = getattr(field, "type_", None)
     field_kwargs.setdefault(
-        "type_",
+        "type",
         convert_pydantic_type(
             declared_type, field, registry, parent_type=parent_type, model=model
         ),


### PR DESCRIPTION
# Fix same error as in #63 but in `convert_pydantic_input_field`

Please describe the feature(s) added, bug(s) fixed, etc here at a high level,
and go into detail in further paragraphs if necessary.
