### PR TITLE
Mapping pydantic.Field.alias attr as graphene.Field.name

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -125,7 +125,8 @@ def convert_pydantic_field(
     )
     field_kwargs.setdefault("required", field.required)
     field_kwargs.setdefault("default_value", field.default)
-    field_kwargs.setdefault("name", field.alias)
+    if field.has_alias:
+        field_kwargs.setdefault("name", field.alias)
     # TODO: find a better way to get a field's description. Some ideas include:
     # - hunt down the description from the field's schema, or the schema
     #   from the field's base model

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -125,6 +125,7 @@ def convert_pydantic_field(
     )
     field_kwargs.setdefault("required", field.required)
     field_kwargs.setdefault("default_value", field.default)
+    field_kwargs.setdefault("name", field.alias)
     # TODO: find a better way to get a field's description. Some ideas include:
     # - hunt down the description from the field's schema, or the schema
     #   from the field's base model


### PR DESCRIPTION
This PR fixes #38.

## Graphene sample

In other words, the same behavior as this working graphene can be made to work for a pydantic model
```python
import graphene


class Model(graphene.ObjectType):
    class_ = graphene.String(name='class')


class Query(graphene.ObjectType):
    model = graphene.Field(Model)

    @staticmethod
    def resolve_model(parent, info):
        return Model(class_='test')


schema = graphene.Schema(query=Query)
print(schema)
print(schema.execute('{model {class}}'))
```

## Graphene-pydantic sample

After this patch, this script works, so perhaps this patch is good. I have not been able to fully verify the other behavior.

```python
import graphene
import pydantic

import graphene_pydantic


class Model(pydantic.BaseModel):
    class_: str = pydantic.Field(alias='class')


class GrapheneModel(graphene_pydantic.PydanticObjectType):
    class Meta:
        model = Model


model = Model(**{'class': 'test'})
print(model)


class Query(graphene.ObjectType):
    model = graphene.Field(GrapheneModel)
    hello = graphene.String()

    @staticmethod
    def resolve_model(parent, info):
        return Model(**{'class': 'test'})

schema = graphene.Schema(query=Query)
print(schema)
print(schema.execute('{model {class}}'))
```

---
sample output
```
class_='test'
type Query {
  model: GrapheneModel
  hello: String
}

type GrapheneModel {
  class: String!
}

ExecutionResult(data={'model': {'class': 'test'}}, errors=None)
```
Advice is welcome!