### PR TITLE
Support subclasses of datetime, date, time

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -236,6 +236,12 @@ def find_graphene_type(
         return Enum.from_enum(type_)
     elif issubclass(type_, str):
         return String
+    elif issubclass(type_, datetime.datetime):
+        return DateTime
+    elif issubclass(type_, datetime.date):
+        return Date
+    elif issubclass(type_, datetime.time):
+        return Time
     else:
         raise ConversionError(
             f"Don't know how to convert the Pydantic field {field!r} ({field.type_})"

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -174,25 +174,25 @@ def find_graphene_type(
     Map a native Python type to a Graphene-supported Field type, where possible,
     throwing an error if we don't know what to map it to.
     """
-    if issubclass(type_, uuid.UUID):
+    if type_ == uuid.UUID:
         return UUID
-    elif issubclass(type_, str) or issubclass(type_, bytes):
+    elif type_ in (str, bytes):
         return String
-    elif issubclass(type_, datetime.datetime):
+    elif type_ == datetime.datetime:
         return DateTime
-    elif issubclass(type_, datetime.date):
+    elif type_ == datetime.date:
         return Date
-    elif issubclass(type_, datetime.time):
+    elif type_ == datetime.time:
         return Time
-    elif issubclass(type_, bool):
+    elif type_ == bool:
         return Boolean
-    elif issubclass(type_, float):
+    elif type_ == float:
         return Float
-    elif issubclass(type_, decimal.Decimal):
+    elif type_ == decimal.Decimal:
         return GrapheneDecimal if DECIMAL_SUPPORTED else Float
-    elif issubclass(type_, int):
+    elif type_ == int:
         return Int
-    elif issubclass(type_, tuple) or issubclass(type_, list) or issubclass(type_, set):
+    elif type_ in (tuple, list, set):
         # TODO: do Sets really belong here?
         return List
     elif registry and registry.get_type_for_model(type_):

--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -174,25 +174,25 @@ def find_graphene_type(
     Map a native Python type to a Graphene-supported Field type, where possible,
     throwing an error if we don't know what to map it to.
     """
-    if type_ == uuid.UUID:
+    if issubclass(type_, uuid.UUID):
         return UUID
-    elif type_ in (str, bytes):
+    elif issubclass(type_, str) or issubclass(type_, bytes):
         return String
-    elif type_ == datetime.datetime:
+    elif issubclass(type_, datetime.datetime):
         return DateTime
-    elif type_ == datetime.date:
+    elif issubclass(type_, datetime.date):
         return Date
-    elif type_ == datetime.time:
+    elif issubclass(type_, datetime.time):
         return Time
-    elif type_ == bool:
+    elif issubclass(type_, bool):
         return Boolean
-    elif type_ == float:
+    elif issubclass(type_, float):
         return Float
-    elif type_ == decimal.Decimal:
+    elif issubclass(type_, decimal.Decimal):
         return GrapheneDecimal if DECIMAL_SUPPORTED else Float
-    elif type_ == int:
+    elif issubclass(type_, int):
         return Int
-    elif type_ in (tuple, list, set):
+    elif issubclass(type_, tuple) or issubclass(type_, list) or issubclass(type_, set):
         # TODO: do Sets really belong here?
         return List
     elif registry and registry.get_type_for_model(type_):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -49,6 +49,10 @@ def test_default_values():
     assert field.default_value == "hi"
 
 
+class DatetimeSubclass(datetime.datetime):
+    """This is a subclass of the datetime class"""
+
+
 @pytest.mark.parametrize(
     "input, expected",
     [
@@ -60,6 +64,8 @@ def test_default_values():
         ((datetime.date, datetime.date(2019, 1, 1)), graphene.Date),
         ((datetime.time, datetime.time(15, 29)), graphene.Time),
         ((datetime.datetime, datetime.datetime(2019, 1, 1, 1, 37)), graphene.DateTime),
+        # Tests support for datetime mocking libraries like Freezegun
+        ((datetime.datetime, DatetimeSubclass(2019, 1, 1, 1, 37)), graphene.DateTime),
     ],
 )
 def test_builtin_scalars(input, expected):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -49,10 +49,6 @@ def test_default_values():
     assert field.default_value == "hi"
 
 
-class DatetimeSubclass(datetime.datetime):
-    """This is a subclass of the datetime class"""
-
-
 @pytest.mark.parametrize(
     "input, expected",
     [
@@ -64,8 +60,6 @@ class DatetimeSubclass(datetime.datetime):
         ((datetime.date, datetime.date(2019, 1, 1)), graphene.Date),
         ((datetime.time, datetime.time(15, 29)), graphene.Time),
         ((datetime.datetime, datetime.datetime(2019, 1, 1, 1, 37)), graphene.DateTime),
-        # Tests support for datetime mocking libraries like Freezegun
-        ((datetime.datetime, DatetimeSubclass(2019, 1, 1, 1, 37)), graphene.DateTime),
     ],
 )
 def test_builtin_scalars(input, expected):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -48,6 +48,15 @@ def test_default_values():
     assert field.type == graphene.String
     assert field.default_value == "hi"
 
+class DatetimeSubclass(datetime.datetime):
+    pass
+
+class TimeSubclass(datetime.time):
+    pass
+
+class DateSubclass(datetime.date):
+    pass
+
 
 @pytest.mark.parametrize(
     "input, expected",
@@ -60,6 +69,10 @@ def test_default_values():
         ((datetime.date, datetime.date(2019, 1, 1)), graphene.Date),
         ((datetime.time, datetime.time(15, 29)), graphene.Time),
         ((datetime.datetime, datetime.datetime(2019, 1, 1, 1, 37)), graphene.DateTime),
+        # Tests support for datetime mocking libraries like Freezegun
+        ((DatetimeSubclass, DatetimeSubclass(2019, 1, 1, 1, 37)), graphene.DateTime),
+        ((DateSubclass, DateSubclass(2019, 1, 1)), graphene.Date),
+        ((TimeSubclass, TimeSubclass(15, 29)), graphene.Time),
     ],
 )
 def test_builtin_scalars(input, expected):


### PR DESCRIPTION
Fixes #56 

Users should be able to subclass datetimes and still have their datetime converted to the proper Graphene type.

I wanted to apply the `issubclass` logic to all types, but I'm holding off since my main goal is to fix compatibility with date mocking libraries like Freezegun.

## Testing

I ran `poetry run pytest` locally with all 40 tests passing.