### PR TITLE
Update pre-commit action, update CONTRIBUTING doc to use poetry

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,11 +6,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.8
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.0
   pytest:
     name: pytest
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,26 @@
 # Contributing Guide
 
 You will need:
-- Python 3.6 or higher
+- Python 3.7 or higher
 
 ## Getting started
 
-To get your development environment set up, run:
+To get your development environment set up, create and activate a virtual
+environment, and install poetry:
 
-```sh
-pip install -e .[dev]
+```
+pipx install poetry
+# or with conda
+conda install poetry
 ```
 
-in an activated virtual environment. This will install the repo version of
+Then install dependencies with poetry:
+
+```sh
+poetry install
+```
+
+This will install the repo version of
 `graphene-pydantic` and then install the development dependencies. Once that
 has completed, you can start developing.
 


### PR DESCRIPTION
# Update pre-commit action, update CONTRIBUTING doc to use poetry

CI is currently broken. Seeing if upgrading the version of the pre-commit/action is a quick win.

Also, updating the CONTRIBUTING.md guide to use poetry, since that's what's used in this repo for managing dependencies.

NOTE: this solves the problem of pre-commit/action failing, but tests are still failing. We'll fix that in https://github.com/graphql-python/graphene-pydantic/pull/88