### PR TITLE
Release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphene_pydantic"
-version = "0.3.0"
+version = "0.4.0"
 description = "Graphene Pydantic integration"
 readme = "README.md"
 repository = "https://github.com/graphql-python/graphene-pydantic"
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 keywords = ["api", "graphql", "protocol", "rest", "relay", "graphene", "pydantic", "model"]


### PR DESCRIPTION
Includes a grab-bag of fixes since v0.3.0, including:
 - mark Python 3.11 as supported
 - handle subclasses of built-in types
 - Graphene 2.x compatibility
 - support Default field resolver
 - Fixes to tests and switch to `nox` instead of `tox` for tests