### PR TITLE
compat: Restore Graphene 2 support

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -20,6 +20,7 @@ from graphene import (
     String,
     Union,
 )
+import graphene
 from graphene.types.base import BaseType
 from graphene.types.datetime import Date, DateTime, Time
 from pydantic import BaseModel
@@ -30,6 +31,8 @@ from .registry import Registry
 from .util import construct_union_class_name
 
 from pydantic import fields
+
+GRAPHENE2 = graphene.VERSION[0] < 3
 
 SHAPE_SINGLETON = (fields.SHAPE_SINGLETON,)
 SHAPE_SEQUENTIAL = (
@@ -89,7 +92,7 @@ def convert_pydantic_input_field(
     """
     declared_type = getattr(field, "type_", None)
     field_kwargs.setdefault(
-        "type_",
+        "type" if GRAPHENE2 else "type_",
         convert_pydantic_type(
             declared_type, field, registry, parent_type=parent_type, model=model
         ),
@@ -118,7 +121,7 @@ def convert_pydantic_field(
     """
     declared_type = getattr(field, "type_", None)
     field_kwargs.setdefault(
-        "type",
+        "type" if GRAPHENE2 else "type_",
         convert_pydantic_type(
             declared_type, field, registry, parent_type=parent_type, model=model
         ),

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,10 +7,15 @@ from nox import parametrize, session
     "pydantic",
     ("1.9", "1.10", "1.7", "1.8"),
 )
-def tests(session, pydantic):
+@parametrize("graphene", ("2.1.9", "3"))
+def tests(session, pydantic, graphene):
     if sys.version_info > (3, 10) and pydantic in ("1.7", "1.8"):
         return session.skip()
+    if sys.version_info > (3, 10) and graphene != "3":
+        # Graphene 2.x doesn't support Python 3.11
+        return session.skip()
     session.install(f"pydantic=={pydantic}")
+    session.install(f"graphene=={graphene}")
     session.install("pytest", "pytest-cov", ".")
     session.run(
         "pytest", "-v", "tests/", "--cov-report=term-missing", "--cov=graphene_pydantic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphene_pydantic"
-version = "0.4.1"
+version = "0.4.2"
 description = "Graphene Pydantic integration"
 readme = "README.md"
 repository = "https://github.com/graphql-python/graphene-pydantic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["api", "graphql", "protocol", "rest", "relay", "graphene", "pydantic
 
 [tool.poetry.dependencies]
 python = "^3.7"
-graphene = ">=3.0"
+graphene = ">=2.1.8"
 pydantic = [
     { version = ">=1.0,<2.0", python = ">3.6,<3.12" },
     { version = ">=1.9,<2.0", python = ">=3.10" }


### PR DESCRIPTION
Fix the dependency in `pyproject.toml` and add a test parameter for the
Graphene 2.x case.