### PR TITLE
Remove CLA, update CONTRIBUTING guide with testing and linting instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,22 +24,10 @@ This will install the repo version of
 `graphene-pydantic` and then install the development dependencies. Once that
 has completed, you can start developing.
 
-## Contributor License Agreement
+### Running tests
 
+To run the tests locally, you can simply run `pytest`.
 
-We require all contributors to sign the [Upside CLA](./CONTRIBUTOR_LICENSE_AGREEMENT.md).
-
-In simple terms, the CLA affirms that the work you're contributing is original,
-that you grant Upside permission to use that work (including license to any
-patents necessary), and that Upside may relicense your work for our commercial
-products if necessary. Note that this description is a summary and the specific
-legal terms should be read directly in the CLA.
-
-The CLA does not change the terms of the standard open source license used by
-our software. You are still free to use our projects within your own projects or
-businesses, republish modified source, and more. Please reference the license of
-this project to learn more.
-
-To sign the CLA, open a pull request as usual. If you haven't signed the CLA
-yet, we cannot merge any pull request until the CLA is signed. You only need to
-sign the CLA once.
+In CI, we run tests using [nox](https://nox.thea.codes/en/stable/index.html),
+which runs the test multiple times using different package versions. Run
+`poetry run nox` to run the entire test suite.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,13 @@ To run the tests locally, you can simply run `pytest`.
 In CI, we run tests using [nox](https://nox.thea.codes/en/stable/index.html),
 which runs the test multiple times using different package versions. Run
 `poetry run nox` to run the entire test suite.
+
+### Pre-commit, linting
+
+We use [pre-commit](https://pre-commit.com/) to manage git pre-commit hooks. This
+will fail linting locally so you can see errors before they run in CI. Run `pre-commit install`
+to install the hooks.
+
+To run them manually, run `pre-commit run --all-files`.
+
+To skip them when committing, run `git commit` with the `--no-verify` flag.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ This project depends on third-party code which is subject to the licenses set fo
 
 ### Contributing
 
-Please see the [Contributing Guide](./CONTRIBUTING.md). Note that you must sign the [CLA](./CONTRIBUTOR_LICENSE_AGREEMENT.md).
+Please see the [Contributing Guide](./CONTRIBUTING.md).
 
 ### Caveats
 


### PR DESCRIPTION
### Remove CLA, update CONTRIBUTING guide with testing and linting instructions

- Upside Travel no longer exists, remove the CLA.
- Add instructions to run tests to CONTRIBUTING
- Add instructions to run pre-commit and lints to CONTRIBUTING.