### PR TITLE
Fix example to work with Pydantic V2, add test for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ dmypy.json
 
 # PyCharm / IntelliJ
 .idea/
+
+# vim
+*.swp
+*.swo

--- a/examples/departments.py
+++ b/examples/departments.py
@@ -21,8 +21,8 @@ class SalaryModel(pydantic.BaseModel):
 
 
 class EmployeeModel(PersonModel):
-    hired_on: datetime.datetime = None
-    salary: T.Optional[SalaryModel]
+    hired_on: T.Optional[datetime.datetime] = None
+    salary: T.Optional[SalaryModel] = None
 
 
 class ManagerModel(EmployeeModel):
@@ -96,13 +96,13 @@ class Query(graphene.ObjectType):
                         salary=SalaryModel(rating="GS-9", amount=75000.23),
                         hired_on=datetime.datetime(2019, 1, 1, 15, 26),
                     ),
-                    EmployeeModel(id=uuid.uuid4(), name="Derek"),
+                    EmployeeModel(id=uuid.uuid4(), name="Derek", salary=None),
                 ],
             )
         ]
 
 
-if __name__ == "__main__":
+def main():
     schema = graphene.Schema(query=Query)
     query = """
         query {
@@ -128,7 +128,10 @@ if __name__ == "__main__":
         }
     }
     """
-    result = schema.execute(query)
+    return schema.execute(query)
 
+
+if __name__ == "__main__":
+    result = main()
     print(result.errors)
     print(json.dumps(result.data, indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphene_pydantic"
-version = "0.6.0"
+version = "0.6.1"
 description = "Graphene Pydantic integration"
 readme = "README.md"
 repository = "https://github.com/graphql-python/graphene-pydantic"

--- a/tests/test_examples/test_departments.py
+++ b/tests/test_examples/test_departments.py
@@ -1,0 +1,30 @@
+from examples import departments
+
+
+def test_departments():
+    result = departments.main()
+    assert not result.errors
+
+    deps = result.data["listDepartments"]
+    assert len(deps) == 1
+
+    employees = deps[0]["employees"]
+    assert len(employees) == 3
+
+    def employee_by_name(employees, name):
+        return [e for e in employees if e["name"] == name][0]
+
+    jason = employee_by_name(employees, "Jason")
+    carmen = employee_by_name(employees, "Carmen")
+    derek = employee_by_name(employees, "Derek")
+
+    # Jason is a manager
+    assert jason["teamSize"] == 2
+    assert carmen.get("teamSize") is None
+
+    # some sanity checks on optional fields,
+    # knowing what the test data is
+    assert jason.get("hiredOn") is None
+    assert carmen.get("hiredOn") is not None
+    assert carmen["salary"]["rating"] == "GS-9"
+    assert derek["salary"] is None


### PR DESCRIPTION
## Summary

- Fix `examples/departments.py` to comply with changes in how Pydantic handles Optional and null fields.
- Add test for this example so we automatically catch regressions in the future.
- Add vim .swp and .swo files to the gitignore.

## Details

One thing we missed in the review of the PR to add support for pydantic v2: https://github.com/graphql-python/graphene-pydantic/pull/94, is that the example no longer works and errors out.

This is due to a breaking change in the behavior of Pydantic V2 in regards to optional fields. See this section of the v1 to v2 [migration guide](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields), and this long github issue for more discussion on their treatment of optional / nullable fields: https://github.com/pydantic/pydantic/issues/1223
