### PR TITLE
Handle list[str] as a field, etc.

### DIFF
--- a/graphene_pydantic/converters.py
+++ b/graphene_pydantic/converters.py
@@ -7,6 +7,7 @@ import inspect
 import sys
 import typing as T
 import uuid
+from types import GenericAlias
 from typing import Type, get_origin
 
 import graphene
@@ -238,7 +239,11 @@ def find_graphene_type(
         return registry.get_type_for_model(type_)
     elif registry and (
         isinstance(type_, BaseModel)
-        or (inspect.isclass(type_) and issubclass(type_, BaseModel))
+        or (
+            inspect.isclass(type_)
+            and not isinstance(type_, GenericAlias)
+            and issubclass(type_, BaseModel)
+        )
     ):
         # If it's a Pydantic model that hasn't yet been wrapped with a ObjectType,
         # we can put a placeholder in and request that `resolve_placeholders()`

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,16 +5,30 @@ from nox import parametrize, session
 @session
 @parametrize(
     "pydantic",
-    ("2.0", "2.1", "2.2", "2.3", "2.4"),
+    (
+        (2, 0),
+        (2, 1),
+        (2, 2),
+        (2, 3),
+        (2, 4),
+        (2, 5),
+        (2, 6),
+        (2, 7),
+        (2, 8),
+        (2, 9),
+        (2, 10),
+    ),
 )
-@parametrize("graphene", ("2.1.8", "2.1.9", "3.0", "3.1", "3.2", "3.3"))
+@parametrize("graphene", ("2.1.8", "2.1.9", "3.0", "3.1", "3.2", "3.3", "3.4"))
 def tests(session, pydantic, graphene):
-    if sys.version_info > (3, 10) and pydantic in ("1.7", "1.8"):
+    if sys.version_info > (3, 10) and pydantic in ((1, 7), (1, 8)):
         return session.skip()
     if sys.version_info > (3, 10) and graphene <= "3":
-        # Graphene 2.x doesn't support Python 3.11
         return session.skip()
-    session.install(f"pydantic=={pydantic}")
+    if sys.version_info > (3, 11) and pydantic < (2, 9):
+        return session.skip()
+    pydantic_version_string = ".".join([str(n) for n in pydantic])
+    session.install(f"pydantic=={pydantic_version_string}")
     session.install(f"graphene=={graphene}")
     session.install("pytest", "pytest-cov", ".")
     session.run(

--- a/poetry.lock
+++ b/poetry.lock
@@ -819,5 +819,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
+python-versions = "^3.8"
 content-hash = "8f050cd6fce164a7e7f5999ecacd74720ec5b9c6c70d09c2d7e3bcf9349b0330"

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -154,6 +154,10 @@ def test_iterables():
     field = _convert_field_from_spec("attr", (T.List[int], [1, 2]))
     assert isinstance(field.type.of_type, graphene.types.List)
 
+    if sys.version_info >= (3, 9):
+        field = _convert_field_from_spec("attr", (list[int], [1, 2]))
+        assert isinstance(field.type.of_type, graphene.types.List)
+
     field = _convert_field_from_spec("attr", (list, [1, 2]))
     assert field.type.of_type == graphene.types.List
 


### PR DESCRIPTION
Ran into a bug trying to use `list[int]` as a field type on a `BaseModel` in Python 3.9. (Note it is also broken with Python 3.10.).  Interestingly, things are handled correctly in these versions of python when using `typing.List[str]`, etc., but not when using a bare `list[str]` (even though that is allowed in these python versions).

This pull request fixes the handling of `list[str]` as a field type.

The issue is that, in Python 3.9 (and 3.10), `inspect.isclass(list[str])` returns `True`, but Python still raises an error when you try to call `issubclass(list[str], BaseModel)`. If you explicitly check for being an instance of `types.GenericAlias` though, that resolves this issue, as even in these versions of python `isinstance(list[str], types.GenericAlias)` is `True`.

----

I'll note though that you have the comment:
```python
    # NOTE: this has to come before any `issubclass()` checks, because annotated
    # generic types aren't valid arguments to `issubclass`
```
right below the change I made. I suspect this is below the pydantic model check so that you handle things properly if the pydantic model has that field (maybe? maybe not..), but if it works it might alternatively make sense to just move that branch above this if statement which is passing the `type_` to `issubclass`. But I figured there was a higher chance that that could cause other issues, so I didn't bother.
